### PR TITLE
Added dom-to-img size options

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,9 +11,14 @@ function App() {
     <DraggableText />,
   ]);
 
+  const handoutRef = document.getElementById("holder");
+
   const downloadHandout = () => {
     domtoimage
-      .toPng(document.getElementById("holder"))
+      .toPng(handoutRef, {
+        width: handoutRef.offsetWidth,
+        height: handoutRef.offsetHeight,
+      })
       .then(function (dataUrl) {
         let link = document.createElement("a");
         link.download = "handout.png";


### PR DESCRIPTION
This PR:

- 'fixes' the div width issue by using the width/height features of the dom-to-image library and feeds back the original size of the handout holder element.